### PR TITLE
Feature motor actuator

### DIFF
--- a/components/Utilities/SharedBus/include/CoffeeMakerInfo.h
+++ b/components/Utilities/SharedBus/include/CoffeeMakerInfo.h
@@ -27,12 +27,6 @@ typedef enum
     NORMAL_MODE = 1
 } MicroSwitchMode;
 
-typedef enum
-{
-    AUTO_MODE = 0,
-    MANUAL_MODE = 1    
-} AttributeUpdateMode;
-
 typedef struct 
 {
     bool PowerKey;


### PR DESCRIPTION
TimerID struct was removed from CoffeemakerInfo.h and sent to the DoneCoffeMaker class in the Matter repo.
This PR was assigned to the last hash of the submodule, before merging this PR we should change the submodule hash with their main hash.