### PR TITLE
change size of partitions

### DIFF
--- a/partitions_s3_16m.csv
+++ b/partitions_s3_16m.csv
@@ -5,7 +5,7 @@ nvs,      data, nvs,     0x10000,   0xC000,
 nvs_keys, data, nvs_keys,,          0x1000, encrypted
 otadata,  data, ota,     ,          0x2000
 phy_init, data, phy,     ,          0x1000,
-ota_0,    app,  ota_0,   ,          0x3E0000,
-ota_1,    app,  ota_1,   ,          0x3E0000,
-fctry,    data, nvs,     ,          0x3E0000,
+ota_0,    app,  ota_0,   0x20000,   0x650000,
+ota_1,    app,  ota_1,   0x670000,  0x650000,
+fctry,    data, nvs,     0xCC0000,  0x6000,
 storage,  data, spiffs,  ,          1M


### PR DESCRIPTION
## Changes Made
- Change the size of the factory (fctry) partition.
- Add start address to some partition

## Motivation
We initially misunderstood the meaning of the factory partition. It doesn't have to be as large as the app partition, it's just enough to store the manufacturer's parameters. We added its size to the two OTA partitions.

## Related Issues
noting

@DoneTech-IoT/iot-dev